### PR TITLE
API requests routing module

### DIFF
--- a/source/request_router/RequestRouter.cpp
+++ b/source/request_router/RequestRouter.cpp
@@ -13,8 +13,8 @@ namespace Router
         if (func == services.end())
         {
             return Http::Response(
-                Http::Response::Status::BadRequest,
-                R"({"Error":"Bad request. No service for )" + request.uri().raw() + R"("})",
+                Http::Response::Status::NotFound,
+                R"({"error":"no service for )" + request.uri().raw() + R"("})",
                 "application/json");
         }
 
@@ -47,7 +47,7 @@ namespace Router
         auto lookup = services.find(endPoint);
         if (lookup != services.end())
         {
-            lookup->second = func;
+            lookup->second = std::move(func);
         }
         else
         {

--- a/source/request_router/RequestRouter.cpp
+++ b/source/request_router/RequestRouter.cpp
@@ -1,0 +1,57 @@
+#include <iostream>
+
+#include "RequestRouter.h"
+#include "../httpserver/Server.h"
+
+
+namespace Router
+{
+    Http::Response RequestRouter::routeRequest(const Http::Request& request)
+    {
+        auto func = services.find(request.uri().raw());
+
+        if (func == services.end())
+        {
+            return Http::Response(
+                Http::Response::Status::BadRequest,
+                R"({"Error":"Bad request. No service for )" + request.uri().raw() + R"("})",
+                "application/json");
+        }
+
+
+        try
+        {
+            auto result = func->second(request.body());
+            return Http::Response(
+                Http::Response::Status::Ok,
+                result,
+                "application/json");
+        }
+        catch (const std::exception& e)
+        {
+            if (emitExceptionsToStdcerr)
+                std::cerr << "REQUEST ROUTER: Caught exception in execution handler for " + request.uri().raw() + " endpoint: "
+                          << e.what()
+                          << std::endl;
+
+            return Http::Response(
+                Http::Response::Status::InternalServerError,
+                R"({"error":"internal server error"})",
+                "application/json");
+        }
+    }
+
+
+    void RequestRouter::registerEndPointService(const std::string& endPoint, EndpointHandler func)
+    {
+        auto lookup = services.find(endPoint);
+        if (lookup != services.end())
+        {
+            lookup->second = func;
+        }
+        else
+        {
+            services.insert({ endPoint, std::move(func) });
+        }
+    };
+}

--- a/source/request_router/RequestRouter.cpp
+++ b/source/request_router/RequestRouter.cpp
@@ -21,10 +21,14 @@ namespace Router
 
         try
         {
-            auto result = func->second(request.body());
+            std::string body;
+            bool success;
+            std::tie(body, success) = func->second(request.body());
+            auto status = success ? Http::Response::Status::Ok : Http::Response::Status::InternalServerError;
+
             return Http::Response(
-                Http::Response::Status::Ok,
-                result,
+                status,
+                body,
                 "application/json");
         }
         catch (const std::exception& e)

--- a/source/request_router/RequestRouter.h
+++ b/source/request_router/RequestRouter.h
@@ -20,9 +20,9 @@ namespace Router
         /// Szablon lambdy
         /*
          * @param ciało zapytania http (np. JSON)
-         * @return odpowiedź na zapytanie (np. JSON) w postaci std::string.
+         * @return odpowiedź na zapytanie (np. JSON) w postaci std::pair<std::string, bool>. Bool określa pomyślność działania handlera.
          */
-        using EndpointHandler = std::function<std::string(const std::string&)>;
+        using EndpointHandler = std::function<std::pair<std::string, bool>(const std::string&)>;
 
         std::map<std::string, EndpointHandler> services;
 
@@ -41,7 +41,7 @@ namespace Router
         /// Rejestruje handler do wykonania w przypadku żądania http dla podanego endpointa
         /*
          * @param endpoint - ciąg znaków określający dla jakiego endpointa jest przeznaczony handler, np. "/api/ocr"
-         * @param handler - lambda lub obiekt funkcyjny przyjmujący const std::string& i zwracający std::string.
+         * @param handler - lambda lub obiekt funkcyjny przyjmujący const std::string& i zwracający std::pair<std::string, bool>.
          * Jeśli podany end point jest już zarejestrowany, handler jest nadpisywany.
          */
         void registerEndPointService(const std::string& endpoint, EndpointHandler handler);

--- a/source/request_router/RequestRouter.h
+++ b/source/request_router/RequestRouter.h
@@ -1,0 +1,62 @@
+#ifndef PATR_REQUESTROUTER_H
+#define PATR_REQUESTROUTER_H
+
+#include <map>
+#include <string>
+#include <functional>
+
+
+namespace Http
+{
+    class Request;
+    class Response;
+}
+
+namespace Router
+{
+    class RequestRouter
+    {
+    protected:
+        /// Szablon lambdy
+        /*
+         * @param ciało zapytania http (np. JSON)
+         * @return odpowiedź na zapytanie (np. JSON) w postaci std::string.
+         */
+        using EndpointHandler = std::function<std::string(const std::string&)>;
+
+        std::map<std::string, EndpointHandler> services;
+
+    public:
+        RequestRouter()                                = default;
+        RequestRouter(RequestRouter&&)                 = default;
+        RequestRouter& operator=(RequestRouter&&)      = default;
+
+        RequestRouter(const RequestRouter&)            = delete;
+        RequestRouter& operator=(const RequestRouter&) = delete;
+
+
+        /// Flaga określająca, czy router powinien wypisać komunikat na std::cerr w przypadku złapania wyjątku podczas działania handlera.
+        bool emitExceptionsToStdcerr = true;
+
+        /// Rejestruje handler do wykonania w przypadku żądania http dla podanego endpointa
+        /*
+         * @param endpoint - ciąg znaków określający dla jakiego endpointa jest przeznaczony handler, np. "/api/ocr"
+         * @param handler - lambda lub obiekt funkcyjny przyjmujący const std::string& i zwracający std::string.
+         * Jeśli podany end point jest już zarejestrowany, handler jest nadpisywany.
+         */
+        void registerEndPointService(const std::string& endpoint, EndpointHandler handler);
+
+
+        /// Wywołuje odpowiedni handler (na podstawie URI zapytania)
+        /*
+         * @param Request od serwera
+         * @return Odpowiedź do serwera z ciałem zawierającym:
+         *   wynik działania handlera lub
+         *   json z wiadomością o "bad request" jeżeli nie ma obsługi żądanego endpointa lub
+         *   json z wiadomością o "internal server error" jeżeli złapano wyjątek podczas działania handlera.
+         */
+        Http::Response routeRequest(const Http::Request& request);
+    };
+}
+
+#endif //PATR_REQUESTROUTER_H

--- a/source/request_router/RequestRouter.h
+++ b/source/request_router/RequestRouter.h
@@ -52,7 +52,7 @@ namespace Router
          * @param Request od serwera
          * @return Odpowiedź do serwera z ciałem zawierającym:
          *   wynik działania handlera lub
-         *   json z wiadomością o "bad request" jeżeli nie ma obsługi żądanego endpointa lub
+         *   json z wiadomością o "not found" jeżeli nie ma obsługi żądanego endpointa lub
          *   json z wiadomością o "internal server error" jeżeli złapano wyjątek podczas działania handlera.
          */
         Http::Response routeRequest(const Http::Request& request);

--- a/source/request_router/routerExample.cpp
+++ b/source/request_router/routerExample.cpp
@@ -9,7 +9,7 @@ void registerServices(Router::RequestRouter& router)
 {
     router.registerEndPointService("/api/ocr", [](const std::string& s)
     {
-        return R"({"c":"d"})";
+        return std::make_pair<std::string, bool>(R"({"c":"d"})", true);
     });
 }
 

--- a/source/request_router/routerExample.cpp
+++ b/source/request_router/routerExample.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+
+#include "../httpserver/Server.h"
+#include "../httpserver/Socket.h"
+#include "RequestRouter.h"
+
+
+void registerServices(Router::RequestRouter& router)
+{
+    router.registerEndPointService("/api/ocr", [](const std::string& s)
+    {
+        return R"({"c":"d"})";
+    });
+}
+
+
+void routerExample()
+{
+    Router::RequestRouter router;
+    registerServices(router);
+
+    try
+    {
+        Http::Server server("0.0.0.0", "8080", [&router](const Http::Request& r)
+        {
+            return router.routeRequest(r);
+        });
+
+        server.run();
+    }
+    catch (const Tcp::SocketError& e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
+}

--- a/source/request_router/test/RouterTest.cpp
+++ b/source/request_router/test/RouterTest.cpp
@@ -1,0 +1,106 @@
+#define BOOST_TEST_DYN_LINK
+
+#include <boost/test/unit_test.hpp>
+#include "../RequestRouter.h"
+#include "../../httpserver/Server.h"
+
+
+BOOST_AUTO_TEST_SUITE(RequestRouter)
+
+struct FuncObj
+{
+    std::string operator()(const std::string& s)
+    {
+        return "func_obj_response_string";
+    }
+};
+
+
+class TestRouter : public Router::RequestRouter
+{
+public:
+    unsigned long size() { return services.size(); }
+};
+
+
+Http::Request getTestRequest(const std::string& uri, const std::string& content)
+{
+    std::string terminate = Http::CRLF;
+    terminate += terminate;
+    std::string input =
+        "POST " + uri + " HTTP/1.0\r\nContent-Length: "
+        + std::to_string(content.length())
+        + terminate
+        + content;
+
+    Http::Request request;
+    Http::RequestParser parser;
+
+    std::string::iterator it;
+    std::tie(std::ignore, it) = parser.parse(input.begin(), input.end(), request);
+    parser.fill(it, input.end(), request);
+    return request;
+}
+
+
+void registerServices(Router::RequestRouter& r)
+{
+    r.registerEndPointService("/api/test", [](const std::string& s)
+    {
+        return R"({"request":"response"})";
+    });
+
+    r.registerEndPointService("/api/test2", [](const std::string& s)
+    {
+        return "json_response2";
+    });
+
+    r.registerEndPointService("/api/except", [](const std::string& s)
+    {
+        throw std::runtime_error("sample exception");
+        return "except";
+    });
+}
+
+
+BOOST_AUTO_TEST_CASE(RegisteringServices)
+{
+    TestRouter tr;
+    tr.emitExceptionsToStdcerr = false;
+    registerServices(tr);
+
+    BOOST_CHECK(tr.size() == 3);
+
+    // Podmiana handlera
+    tr.registerEndPointService("/api/test2", FuncObj());
+
+    BOOST_CHECK(tr.size() == 3);
+
+    auto response = tr.routeRequest(getTestRequest("/api/test2", "hello"));
+    BOOST_CHECK(response.raw().find("func_obj_response_string") != std::string::npos);
+}
+
+
+BOOST_AUTO_TEST_CASE(Routing)
+{
+    Router::RequestRouter rr;
+    rr.emitExceptionsToStdcerr = false;
+    registerServices(rr);
+
+
+    auto request = getTestRequest("/api/test", "{\"test\":\"router\"}");
+    auto response = rr.routeRequest(request);
+    BOOST_CHECK(response.raw().find(R"({"request":"response"})") != std::string::npos);
+
+
+    auto internal_error_request = getTestRequest("/api/except", "{\"test\":\"router\"}");
+    auto internal_error_response = rr.routeRequest(internal_error_request);
+    BOOST_CHECK(internal_error_response.raw().find(R"({"error":"internal server error"})") != std::string::npos);
+
+
+    auto bad_request = getTestRequest("/api/none", "{\"test\":\"router\"}");
+    auto bad_response = rr.routeRequest(bad_request);
+    BOOST_CHECK(bad_response.raw().find(R"({"Error":"Bad request. No service for /api/none"})") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/source/request_router/test/RouterTest.cpp
+++ b/source/request_router/test/RouterTest.cpp
@@ -98,9 +98,9 @@ BOOST_AUTO_TEST_CASE(Routing)
     BOOST_CHECK(internal_error_response.raw().find(R"({"error":"internal server error"})") != std::string::npos);
 
 
-    auto bad_request = getTestRequest("/api/none", "{\"test\":\"router\"}");
-    auto bad_response = rr.routeRequest(bad_request);
-    BOOST_CHECK(bad_response.raw().find(R"({"Error":"Bad request. No service for /api/none"})") != std::string::npos);
+    auto not_found_request = getTestRequest("/api/none", "{\"test\":\"router\"}");
+    auto not_found_response = rr.routeRequest(not_found_request);
+    BOOST_CHECK(not_found_response.raw().find(R"({"error":"no service for /api/none"})") != std::string::npos);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/source/request_router/test/RouterTest.cpp
+++ b/source/request_router/test/RouterTest.cpp
@@ -9,9 +9,9 @@ BOOST_AUTO_TEST_SUITE(RequestRouter)
 
 struct FuncObj
 {
-    std::string operator()(const std::string& s)
+    std::pair<std::string, bool> operator()(const std::string& s)
     {
-        return "func_obj_response_string";
+        return std::make_pair("func_obj_response_string", true);
     }
 };
 
@@ -45,20 +45,20 @@ Http::Request getTestRequest(const std::string& uri, const std::string& content)
 
 void registerServices(Router::RequestRouter& r)
 {
-    r.registerEndPointService("/api/test", [](const std::string& s)
+    r.registerEndPointService("/api/test", [](const std::string& s) -> std::pair<std::string, bool>
     {
-        return R"({"request":"response"})";
+        return std::make_pair(R"({"request":"response"})", true);
     });
 
     r.registerEndPointService("/api/test2", [](const std::string& s)
     {
-        return "json_response2";
+        return std::make_pair<std::string, bool>("json_response2", true);
     });
 
     r.registerEndPointService("/api/except", [](const std::string& s)
     {
         throw std::runtime_error("sample exception");
-        return "except";
+        return std::make_pair<std::string, bool>("except", true);
     });
 }
 
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(Routing)
     auto internal_error_request = getTestRequest("/api/except", "{\"test\":\"router\"}");
     auto internal_error_response = rr.routeRequest(internal_error_request);
     BOOST_CHECK(internal_error_response.raw().find(R"({"error":"internal server error"})") != std::string::npos);
-
+    
 
     auto not_found_request = getTestRequest("/api/none", "{\"test\":\"router\"}");
     auto not_found_response = rr.routeRequest(not_found_request);


### PR DESCRIPTION
Mały moduł służący do przekierowywania żądań HTTP na podstawie endpointa w Http::Request.

Po dopasowaniu URI Requesta jest odpalany z danym endpointem handler (lambda).

Przykłady zastosowania w routerExample.cpp oraz w RouterTest.cpp.
Feedback i propozycje usprawnienia lub ficzerów mile widziane.