### PR TITLE
Rozdzielenie Server.h na dwa pliki nagłówkowe

### DIFF
--- a/source/httpserver/Server.cpp
+++ b/source/httpserver/Server.cpp
@@ -1,4 +1,6 @@
 #include "Server.h"
+#include "ServerUtilities.h"
+#include "Socket.h"
 #include <csignal>
 #include <sstream>
 #include <string>
@@ -6,34 +8,66 @@
 
 namespace {
 
-    std::map<Http::Response::Status, std::string> StockResponse = {
-    { Http::Response::Status::Ok, "HTTP/1.0 200 OK\r\n" },
-    { Http::Response::Status::Created, "HTTP/1.0 201 Created\r\n" },
-    { Http::Response::Status::Accepted, "HTTP/1.0 202 Accepted\r\n" },
-    { Http::Response::Status::NoContent, "HTTP/1.0 204 No Content\r\n" },
-    { Http::Response::Status::MultipleChoices, "HTTP/1.0 300 Multiple Choices\r\n" },
-    { Http::Response::Status::MovedPermanently, "HTTP/1.0 301 Moved Permanently\r\n" },
-    { Http::Response::Status::Found, "HTTP/1.0 302 Found\r\n" },
-    { Http::Response::Status::NotModified, "HTTP/1.0 304 Not Modified\r\n" },
-    { Http::Response::Status::BadRequest, "HTTP/1.0 400 Bad request\r\n" },
-    { Http::Response::Status::Unauthorized, "HTTP/1.0 401 Unauthorized\r\n" },
-    { Http::Response::Status::Forbidden, "HTTP/1.0 403 Forbidden\r\n" },
-    { Http::Response::Status::NotFound, "HTTP/1.0 404 Not Found\r\n" },
-    { Http::Response::Status::RequestTimeout, "HTTP/1.0 408 Request Timeout\r\n" },
-    { Http::Response::Status::InternalServerError, "HTTP/1.0 500 Internal Server Error\r\n" },
-    { Http::Response::Status::NotImplemented, "HTTP/1.0 501 Not Implemented\r\n" },
-    { Http::Response::Status::BadGateway, "HTTP/1.0 502 Bad Gateway\r\n" },
-    { Http::Response::Status::ServiceUnavailable, "HTTP/1.0 503 Service Unavailable\r\n" }
+    std::map<Http::ResponseStatus, std::string> StockResponse = {
+    { Http::ResponseStatus::Ok, "HTTP/1.0 200 OK\r\n" },
+    { Http::ResponseStatus::Created, "HTTP/1.0 201 Created\r\n" },
+    { Http::ResponseStatus::Accepted, "HTTP/1.0 202 Accepted\r\n" },
+    { Http::ResponseStatus::NoContent, "HTTP/1.0 204 No Content\r\n" },
+    { Http::ResponseStatus::MultipleChoices, "HTTP/1.0 300 Multiple Choices\r\n" },
+    { Http::ResponseStatus::MovedPermanently, "HTTP/1.0 301 Moved Permanently\r\n" },
+    { Http::ResponseStatus::Found, "HTTP/1.0 302 Found\r\n" },
+    { Http::ResponseStatus::NotModified, "HTTP/1.0 304 Not Modified\r\n" },
+    { Http::ResponseStatus::BadRequest, "HTTP/1.0 400 Bad request\r\n" },
+    { Http::ResponseStatus::Unauthorized, "HTTP/1.0 401 Unauthorized\r\n" },
+    { Http::ResponseStatus::Forbidden, "HTTP/1.0 403 Forbidden\r\n" },
+    { Http::ResponseStatus::NotFound, "HTTP/1.0 404 Not Found\r\n" },
+    { Http::ResponseStatus::RequestTimeout, "HTTP/1.0 408 Request Timeout\r\n" },
+    { Http::ResponseStatus::InternalServerError, "HTTP/1.0 500 Internal Server Error\r\n" },
+    { Http::ResponseStatus::NotImplemented, "HTTP/1.0 501 Not Implemented\r\n" },
+    { Http::ResponseStatus::BadGateway, "HTTP/1.0 502 Bad Gateway\r\n" },
+    { Http::ResponseStatus::ServiceUnavailable, "HTTP/1.0 503 Service Unavailable\r\n" }
     };
 
-    Tcp::ConstBuffer MakeBuffer(Http::Response::Status status)
+    Tcp::ConstBuffer MakeBuffer(Http::ResponseStatus status)
     {
         return Tcp::MakeBuffer(const_cast<const std::string&>(StockResponse[status]));
     }
 }
 
+namespace Http {
 
-Http::Connection::Connection(Tcp::Socket socket, HandlerStrategy& handler) : socket(std::move(socket)), globalHandler(handler)
+struct Connection::ConnectionPimpl
+{
+    ConnectionPimpl(Tcp::Socket socket) : socket(std::move(socket))
+    {
+    }
+
+    Tcp::Socket socket;
+    RequestParser parser;
+    Request request;
+};
+
+struct Server::ServerPimpl
+{
+    ServerPimpl(ServicePtr service) : 
+        service(std::move(service)),
+        acceptor(*this->service),
+        signals(*this->service)
+    {
+    }
+
+    Server::ServicePtr service;
+    Tcp::Acceptor acceptor;
+    Tcp::SignalSet signals;
+};
+
+}
+
+Http::Connection::Connection(Tcp::Socket socket, HandlerStrategy& handler) : pimpl(new ConnectionPimpl(std::move(socket))), globalHandler(handler)
+{
+}
+
+Http::Connection::~Connection()
 {
 }
 
@@ -44,23 +78,23 @@ void Http::Connection::start()
 
 void Http::Connection::stop()
 {
-    socket.close();
+    pimpl->socket.close();
 }
 
 void Http::Connection::read()
 {
     auto self = shared_from_this();
-    socket.asyncReadSome(Tcp::MakeBuffer(buffer),
+    pimpl->socket.asyncReadSome(Tcp::MakeBuffer(buffer),
         [this, self](int ec, std::size_t bytes)
     {
         if (!ec) // Nie wykryto błędu.
         {
             RequestParser::Result result;
             auto it = buffer.begin();
-            std::tie(result, it) = parser.parse(buffer.begin(), buffer.begin() + bytes, request);
+            std::tie(result, it) = pimpl->parser.parse(buffer.begin(), buffer.begin() + bytes, pimpl->request);
             if (result == RequestParser::Result::Good) // Zapytanie sparsowane poprawnie.
             {
-                if (parser.fill(it, buffer.begin() + bytes, request)) // Zacznij czyta? cia?o.
+                if (pimpl->parser.fill(it, buffer.begin() + bytes, pimpl->request)) // Zacznij czyta? cia?o.
                 {
                     write(); // Jeżeli ciało nie zostało wykryte, przejdź do odpowiedzi.
                 }
@@ -71,9 +105,9 @@ void Http::Connection::read()
             }
             else if (result == RequestParser::Result::Bad) // Zapytanie sparsowane niepoprawnie.
             {
-                globalHandler.respond(socket, Response::Status::BadRequest); // Od razu odpowiedz klientowi.
-                socket.shutdown();
-                socket.close(); // Zamknij gniazdo.
+                globalHandler.respond(pimpl->socket, ResponseStatus::BadRequest); // Od razu odpowiedz klientowi.
+                pimpl->socket.shutdown();
+                pimpl->socket.close(); // Zamknij gniazdo.
                 globalHandler.stop(shared_from_this());
             }
             else
@@ -86,13 +120,13 @@ void Http::Connection::read()
             try
             {
                 if (ec > 1)
-                    globalHandler.respond(socket, Response::Status::RequestTimeout);
+                    globalHandler.respond(pimpl->socket, ResponseStatus::RequestTimeout);
             }
             catch (const Tcp::SendError&)
             {
 
             }
-            socket.shutdown();
+            pimpl->socket.shutdown();
             globalHandler.stop(shared_from_this());
         }
     }
@@ -102,12 +136,12 @@ void Http::Connection::read()
 void Http::Connection::readBody()
 {
     auto self = shared_from_this();
-    socket.asyncReadSome(Tcp::MakeBuffer(buffer),
+    pimpl->socket.asyncReadSome(Tcp::MakeBuffer(buffer),
         [this, self](int ec, std::size_t bytes)
     {
         if (!ec)
         {
-            if (parser.fill(buffer.begin(), buffer.begin() + bytes, request))
+            if (pimpl->parser.fill(buffer.begin(), buffer.begin() + bytes, pimpl->request))
             {
                 write();
             }
@@ -120,13 +154,13 @@ void Http::Connection::readBody()
         {
             try
             {
-                globalHandler.respond(socket, Response::Status::RequestTimeout);
+                globalHandler.respond(pimpl->socket, ResponseStatus::RequestTimeout);
             }
             catch (const Tcp::SendError&)
             {
 
             }
-            socket.shutdown();
+            pimpl->socket.shutdown();
             globalHandler.stop(shared_from_this());
         }
     }
@@ -141,7 +175,7 @@ void Http::Connection::write()
         {
             try
             {
-                socket.write(Tcp::MakeBuffer(handler(request).raw()));
+                pimpl->socket.write(Tcp::MakeBuffer(handler(pimpl->request).raw()));
             }
             catch (const Tcp::SendError&)
             {
@@ -149,7 +183,7 @@ void Http::Connection::write()
             }
         }
     );
-    socket.shutdown();
+    pimpl->socket.shutdown();
     globalHandler.stop(shared_from_this());
 }
 
@@ -163,12 +197,12 @@ void Http::ThreadedHandlerStrategy::handle(ConnectionResponse response)
     {
         response([](const Request&)
         {
-            return Response(Response::Status::InternalServerError, "", "");
+            return Response(ResponseStatus::InternalServerError, "", "");
         });
     }
 }
 
-void Http::ThreadedHandlerStrategy::respond(Tcp::Socket& socket, Response::Status stockResponse)
+void Http::ThreadedHandlerStrategy::respond(Tcp::Socket& socket, ResponseStatus stockResponse)
 {
     socket.write(MakeBuffer(stockResponse));
 }
@@ -184,7 +218,7 @@ void Http::ThreadedHandlerStrategy::stop(ConnectionPtr connection)
     connections.erase(connection);
 }
 
-Http::Response::Response(Status code, const BodyType & content, const MediaType & mediaType) : responseStatus(code), response(content)
+Http::Response::Response(ResponseStatus code, const BodyType & content, const MediaType & mediaType) : responseStatus(code), response(content)
 {
     if (content.length() > 0) // w przypadku braku ciała nie uzupełniaj nagłówków.
     {
@@ -206,7 +240,7 @@ std::string Http::Response::raw() const
     return retval;
 }
 
-Http::Response::Status Http::Response::status() const
+Http::ResponseStatus Http::Response::status() const
 {
     return responseStatus;
 }
@@ -571,7 +605,7 @@ const Http::HeaderContainer& Http::Request::headers() const
     return headerCollection;
 }
 
-const Http::BodyType Http::Request::body() const
+const Http::BodyType& Http::Request::body() const
 {
     return content;
 }
@@ -713,22 +747,20 @@ std::vector<std::string> Http::Uri::segments() const
 }
 
 Http::Server::Server(const std::string& host, const std::string& port, ServicePtr service, StrategyPtr globalHandler) :
-    service(std::move(service)),
-    acceptor(*this->service),
-    signals(*this->service),
+    pimpl(new ServerPimpl(std::move(service))),
     globalHandler(std::move(globalHandler))//(handler)
 {
-    signals.add(SIGINT); // nie wspierane na Windows
-    signals.add(SIGTERM);
+    pimpl->signals.add(SIGINT); // nie wspierane na Windows
+    pimpl->signals.add(SIGTERM);
 #if defined(SIGQUIT)
     signals.add(SIGQUIT);
 #endif // defined(SIGQUIT)
 
-    Tcp::Endpoint endpoint = this->service->getFactory()->resolve(host, port);
-    acceptor.open(endpoint.protocol());
-    acceptor.setOption(Tcp::Option::ReuseAddress(true));
-    acceptor.bind(endpoint.address());
-    acceptor.listen(50);
+    Tcp::Endpoint endpoint = this->pimpl->service->getFactory()->resolve(host, port);
+    pimpl->acceptor.open(endpoint.protocol());
+    pimpl->acceptor.setOption(Tcp::Option::ReuseAddress(true));
+    pimpl->acceptor.bind(endpoint.address());
+    pimpl->acceptor.listen(50);
     accept();
 }
 
@@ -737,14 +769,23 @@ Http::Server::Server(const std::string & host, const std::string & port, Request
 {
 }
 
+Http::Server::Server(const std::string & host, const std::string & port, RequestHandler handler)
+    : Server(host, port, ServicePtr(new Tcp::StreamService()), StrategyPtr(new ThreadedHandlerStrategy(std::move(handler))))
+{
+}
+
+Http::Server::~Server()
+{
+}
+
 int Http::Server::run()
 {
-    return service->run();
+    return pimpl->service->run();
 }
 
 void Http::Server::accept()
 {
-    acceptor.asyncAccept([this](Tcp::Socket socket)
+    pimpl->acceptor.asyncAccept([this](Tcp::Socket socket)
     {
         globalHandler->start(std::make_shared<Connection>(std::move(socket), *globalHandler));
         accept();

--- a/source/httpserver/Server.cpp
+++ b/source/httpserver/Server.cpp
@@ -8,27 +8,27 @@
 
 namespace {
 
-    std::map<Http::ResponseStatus, std::string> StockResponse = {
-    { Http::ResponseStatus::Ok, "HTTP/1.0 200 OK\r\n" },
-    { Http::ResponseStatus::Created, "HTTP/1.0 201 Created\r\n" },
-    { Http::ResponseStatus::Accepted, "HTTP/1.0 202 Accepted\r\n" },
-    { Http::ResponseStatus::NoContent, "HTTP/1.0 204 No Content\r\n" },
-    { Http::ResponseStatus::MultipleChoices, "HTTP/1.0 300 Multiple Choices\r\n" },
-    { Http::ResponseStatus::MovedPermanently, "HTTP/1.0 301 Moved Permanently\r\n" },
-    { Http::ResponseStatus::Found, "HTTP/1.0 302 Found\r\n" },
-    { Http::ResponseStatus::NotModified, "HTTP/1.0 304 Not Modified\r\n" },
-    { Http::ResponseStatus::BadRequest, "HTTP/1.0 400 Bad request\r\n" },
-    { Http::ResponseStatus::Unauthorized, "HTTP/1.0 401 Unauthorized\r\n" },
-    { Http::ResponseStatus::Forbidden, "HTTP/1.0 403 Forbidden\r\n" },
-    { Http::ResponseStatus::NotFound, "HTTP/1.0 404 Not Found\r\n" },
-    { Http::ResponseStatus::RequestTimeout, "HTTP/1.0 408 Request Timeout\r\n" },
-    { Http::ResponseStatus::InternalServerError, "HTTP/1.0 500 Internal Server Error\r\n" },
-    { Http::ResponseStatus::NotImplemented, "HTTP/1.0 501 Not Implemented\r\n" },
-    { Http::ResponseStatus::BadGateway, "HTTP/1.0 502 Bad Gateway\r\n" },
-    { Http::ResponseStatus::ServiceUnavailable, "HTTP/1.0 503 Service Unavailable\r\n" }
+    std::map<Http::Response::Status, std::string> StockResponse = {
+    { Http::Response::Status::Ok, "HTTP/1.0 200 OK\r\n" },
+    { Http::Response::Status::Created, "HTTP/1.0 201 Created\r\n" },
+    { Http::Response::Status::Accepted, "HTTP/1.0 202 Accepted\r\n" },
+    { Http::Response::Status::NoContent, "HTTP/1.0 204 No Content\r\n" },
+    { Http::Response::Status::MultipleChoices, "HTTP/1.0 300 Multiple Choices\r\n" },
+    { Http::Response::Status::MovedPermanently, "HTTP/1.0 301 Moved Permanently\r\n" },
+    { Http::Response::Status::Found, "HTTP/1.0 302 Found\r\n" },
+    { Http::Response::Status::NotModified, "HTTP/1.0 304 Not Modified\r\n" },
+    { Http::Response::Status::BadRequest, "HTTP/1.0 400 Bad request\r\n" },
+    { Http::Response::Status::Unauthorized, "HTTP/1.0 401 Unauthorized\r\n" },
+    { Http::Response::Status::Forbidden, "HTTP/1.0 403 Forbidden\r\n" },
+    { Http::Response::Status::NotFound, "HTTP/1.0 404 Not Found\r\n" },
+    { Http::Response::Status::RequestTimeout, "HTTP/1.0 408 Request Timeout\r\n" },
+    { Http::Response::Status::InternalServerError, "HTTP/1.0 500 Internal Server Error\r\n" },
+    { Http::Response::Status::NotImplemented, "HTTP/1.0 501 Not Implemented\r\n" },
+    { Http::Response::Status::BadGateway, "HTTP/1.0 502 Bad Gateway\r\n" },
+    { Http::Response::Status::ServiceUnavailable, "HTTP/1.0 503 Service Unavailable\r\n" }
     };
 
-    Tcp::ConstBuffer MakeBuffer(Http::ResponseStatus status)
+    Tcp::ConstBuffer MakeBuffer(Http::Response::Status status)
     {
         return Tcp::MakeBuffer(const_cast<const std::string&>(StockResponse[status]));
     }
@@ -105,7 +105,7 @@ void Http::Connection::read()
             }
             else if (result == RequestParser::Result::Bad) // Zapytanie sparsowane niepoprawnie.
             {
-                globalHandler.respond(pimpl->socket, ResponseStatus::BadRequest); // Od razu odpowiedz klientowi.
+                globalHandler.respond(pimpl->socket, Response::Status::BadRequest); // Od razu odpowiedz klientowi.
                 pimpl->socket.shutdown();
                 pimpl->socket.close(); // Zamknij gniazdo.
                 globalHandler.stop(shared_from_this());
@@ -120,7 +120,7 @@ void Http::Connection::read()
             try
             {
                 if (ec > 1)
-                    globalHandler.respond(pimpl->socket, ResponseStatus::RequestTimeout);
+                    globalHandler.respond(pimpl->socket, Response::Status::RequestTimeout);
             }
             catch (const Tcp::SendError&)
             {
@@ -154,7 +154,7 @@ void Http::Connection::readBody()
         {
             try
             {
-                globalHandler.respond(pimpl->socket, ResponseStatus::RequestTimeout);
+                globalHandler.respond(pimpl->socket, Response::Status::RequestTimeout);
             }
             catch (const Tcp::SendError&)
             {
@@ -197,12 +197,12 @@ void Http::ThreadedHandlerStrategy::handle(ConnectionResponse response)
     {
         response([](const Request&)
         {
-            return Response(ResponseStatus::InternalServerError, "", "");
+            return Response(Response::Status::InternalServerError, "", "");
         });
     }
 }
 
-void Http::ThreadedHandlerStrategy::respond(Tcp::Socket& socket, ResponseStatus stockResponse)
+void Http::ThreadedHandlerStrategy::respond(Tcp::Socket& socket, Response::Status stockResponse)
 {
     socket.write(MakeBuffer(stockResponse));
 }
@@ -218,7 +218,7 @@ void Http::ThreadedHandlerStrategy::stop(ConnectionPtr connection)
     connections.erase(connection);
 }
 
-Http::Response::Response(ResponseStatus code, const BodyType & content, const MediaType & mediaType) : responseStatus(code), response(content)
+Http::Response::Response(Response::Status code, const BodyType & content, const MediaType & mediaType) : responseStatus(code), response(content)
 {
     if (content.length() > 0) // w przypadku braku ciała nie uzupełniaj nagłówków.
     {
@@ -240,7 +240,7 @@ std::string Http::Response::raw() const
     return retval;
 }
 
-Http::ResponseStatus Http::Response::status() const
+Http::Response::Status Http::Response::status() const
 {
     return responseStatus;
 }

--- a/source/httpserver/Server.h
+++ b/source/httpserver/Server.h
@@ -3,20 +3,23 @@
 
 #include <memory>
 
-#include <list>
 #include <array>
 #include <queue>
 #include <vector>
 #include <unordered_set>
-#include <unordered_map>
 
 #include <thread>
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
 
-#include "Socket.h"
+//#include "Socket.h"
 
+namespace Tcp {
+
+class Socket;
+class StreamServiceInterface;
+}
 
 /// Przestrzeń klas i funkcji oraz stałych związanych z działaniem serwera HTTP.
 /**
@@ -27,310 +30,9 @@
  */
 namespace Http {
 
-/// Stała określająca nową linie wykorzystywaną przez HTTP.
-constexpr auto CRLF = "\r\n";
-/// Separator nagłówków HTTP.
-constexpr auto HEADER_SEPARATOR = ": ";
-
-
-
-
-/// Klasa określająca URI.
-/**
- * Pozwala na dekodowanie, tokenizację i segmentację oraz szeregowanie
- * subdomen, katalogów, zapytań GET.
- */
-class Uri
-{
-public:
-    typedef std::unordered_map<std::string, std::string> QueryType;
-
-    /// Przeprowadza dekodowanie z formatu HTTP.
-    static bool Decode(const std::string& in, std::string& out);
-
-    /// Tworzy nowy URI z podanego łańcucha znaków.
-    Uri(const std::string& uri);
-    /// Tworzy pusty URI.
-    Uri();
-
-    /// Zwraca surowy łańcuch znaków w postaci, w jakiej je otrzymał.
-    std::string& raw();
-    const std::string& raw() const;
-    /// Zwraca argumenty zapytania GET
-    /**
-     * Tokenizacja przebiega po pierwszym znaku '?',
-     * rodzielona '&' oraz '='.
-     * Elementy nie są dekodowane.
-     */
-    QueryType query() const;
-    /// Zwraca rodzica katalogu.
-    /**
-     * Dla /foo/bar/ zwraca /foo/bar
-     * Dla /foo/bar zwraca /foo
-     * Elementy nie są dekodowane.
-     */
-    Uri parent() const;
-    /// Zwraca ścieżkę bez argumentów GET.
-    /**
-     * Ścieżka nie jest dekodowana.
-     */
-    Uri absolutePath() const;
-    /// Rozdziela ścieżkę absolutną na poszczególne katalogi.
-    /**
-     * Segmenty nie są dekodowane.
-     */
-    std::vector<std::string> segments() const;
-
-private:
-    std::string uri;
-};
-
-
-
-/// Typ wykorzystywany jako ciało dokumentu HTTP.
-typedef std::string BodyType;
-/// Typ wykorzystywany jako oznaczenie typu MIME.
-typedef std::string MediaType;
-
-
-
-/// Posiada dostępne domyślne metody HTTP.
-namespace RequestMethod
-{
-    constexpr auto OPTIONS = "OPTIONS";
-    constexpr auto GET = "GET";
-    constexpr auto HEAD = "HEAD";
-    constexpr auto POST = "POST";
-    constexpr auto PUT = "PUT";
-    constexpr auto TRACE = "TRACE";
-    constexpr auto CONNECT = "CONNECT";
-    constexpr auto DELETE = "DELETE";
-}
-
-
-
-/// Struktura określająca wersję HTTP.
-struct Version
-{
-    int major, minor;
-};
-
-
-
-/// Typ wykorzystywany do reprezentacji Nagłówka.
-typedef std::pair<std::string /* name */, std::string /* value */> Header;
-/// Typ wykorzystywany do kolekcji nagłówków.
-//typedef std::unordered_map<Header::first_type, Header::second_type> HeaderContainer;
-typedef std::vector<Header> HeaderContainer;
-
-
-
-/// Klasa określająca zapytanie HTTP.
-class Request
-{
-public:
-    /// Zwraca ciąg znaków, jaki otrzymany był w zapytaniu.
-    std::string raw() const;
-    /// Zwraca metodę HTTP.
-    const std::string& method() const;
-    /// Zwraca URI.
-    const Uri& uri() const;
-    /// Zwraca wersję w formacie {}.{}
-    std::string version() const;
-    /// Zwraca kolekcję wszystkich nagłówków.
-    const HeaderContainer& headers() const;
-    /// Zwraca ciało dokumentu.
-    const BodyType body() const;
-
-private:
-    /// Posiada informacje szczegółowe o główynm wierszu.
-    struct RequestLine
-    {
-        std::string method;
-        Uri uri;
-        Version version;
-    } requestLine;
-    
-    HeaderContainer headerCollection;
-    BodyType content;
-
-    friend class RequestParser;
-};
-
-
-
-/// Parser zapytań HTTP.
-/**
- * Jest maszyną stanów w celu optymalizacji asynchronicznego odczytywania zapytań.
- */
-class RequestParser
-{
-public:
-    /// Wynik parsowania.
-    enum class Result
-    {
-        Good, //< Zapytanie poprawne pod względem syntaktycznym.
-        Bad, //< Zapytanie niepoprawne pod względem syntaktycznym.
-        Indeterminate //< Zapytanie dotychczas nie zawierało błędów syntaktycznych.
-    };
-
-    /// Tworzy nowy obiekt.
-    RequestParser();
-
-    /// Przeprowadza parsowanie dla podanego zasięgu.
-    /**
-     * Kontener musi mieć value_type == char lub kompatybilny i
-     * możliwość dostępu sekwencyjnego.
-     */
-    template<typename InputIt>
-    std::pair<Result, InputIt> parse(InputIt begin, InputIt end, Request& request)
-    {
-        while (begin != end)
-        {
-            Result result = consume(*begin++, request);
-            if (result == Result::Good || result == Result::Bad)
-                return std::make_pair(result, begin);
-        }
-        return std::make_pair(Result::Indeterminate, begin);
-    }
-
-    /// Dodaje do ciała zapytania dany zasięg.
-    /**
-     * Przeprowadza sprawdzenie z nagłówkiem Content-Length w celu
-     * okreslenia maksymalnej wielkości ciała zapytania.
-     */
-    template<typename InputIt>
-    static bool fill(InputIt begin, InputIt end, Request& request)
-    {
-        std::size_t max = contentLength(request);
-
-        if (request.content.length() == max)
-            return true;
-
-        while (begin != end)
-        {
-            request.content += *begin++;
-            if (request.content.length() == max)
-                return true;
-        }
-        return false;
-    }
-
-    void reset();
-
-private:
-    /// Zwraca długość ciała dla zapytania HTTP.
-    static int contentLength(const Request& request);
-    /// Sprawdza zgodność znaku w danej chwili dla zapytania.
-    Result consume(char value, Request& request);
-
-    /// Lista możliwych stanów parsera.
-    enum State
-    {
-        MethodStart,
-        Method,
-        Uri,
-        HttpVersionH,
-        HttpVersionT1,
-        HttpVersionT2,
-        HttpVersionP,
-        HttpVersionSlash,
-        HttpVersionMajorStart,
-        HttpVersionMajor,
-        HttpVersionMinorStart,
-        HttpVersionMinor,
-        ExpectingNewline1,
-        HeaderLineStart,
-        HeaderLws,
-        HeaderName,
-        SpaceBeforeHeaderValue,
-        HeaderValue,
-        ExpectingNewline2,
-        ExpectingNewline3
-    } state;
-};
-
-
-
-/// Klasa odpowiedzi HTTP.
-class Response
-{
-public:
-    /// Lista możliwych statusów odpowiedzi wraz z odpowiadającymi kodami.
-    enum class Status
-    {
-        /* Informational */
-        Continue = 100,
-        SwitchingProtocols = 101,
-
-        /* Success */
-        Ok = 200,
-        Created = 201,
-        Accepted = 202,
-        NonAuthoritativeInformation =  203,
-        NoContent = 204,
-        ResetContent = 205,
-        PartialContent = 206,
-
-        /* Redirection */
-        MultipleChoices = 300,
-        MovedPermanently = 301,
-        Found = 302,
-        SeeOther = 303,
-        NotModified = 304,
-        UseProxy = 305,
-        TemporaryRedirect = 307,
-
-        /* Client Error */
-        BadRequest = 400,
-        Unauthorized = 401,
-        PaymentRequired = 402,
-        Forbidden = 403,
-        NotFound = 404,
-        MethodNotAllowed = 405,
-        NotAcceptable = 406,
-        ProxyAuthenticationRequired = 407,
-        RequestTimeout = 408,
-        Conflict = 409,
-        Gone = 410,
-        LengthRequired = 411,
-        PreconditionFailed = 412,
-        RequestEntityTooLarge = 413,
-        RequestUriTooLarge = 414,
-        UnsupportedMediaType = 415,
-        RequestedRangeNotSatisfiable = 416,
-        ExpectationFailed = 417,
-
-        /* Server Error */
-        InternalServerError = 500,
-        NotImplemented = 501,
-        BadGateway = 502,
-        ServiceUnavailable = 503,
-        GatewayTimeout = 504,
-        HttpVersionNotSupported = 505
-    };
-
-    /// Tworzy odpowiedź z danym kodem i ciałem o podanym typie mediów.
-    Response(Status code, const BodyType& content, const MediaType& mediaType);
-
-    /// Zwraca odpowiedź w formie, jaka zostanie wysłana do klienta.
-    std::string raw() const;
-    /// Zwraca status odpowiedzi.
-    Status status() const;
-
-    /// Posiada nagłówki możliwe do modyfikacji w zależności od potrzeb.
-    /**
-     * Nagłówki nie przechodzą walidacji syntaktycznej.
-     */
-    HeaderContainer headers;
-
-private:
-    Status responseStatus;
-    std::string response;
-};
-
-
-
+enum class ResponseStatus;
+class Response;
+class Request;
 class HandlerStrategy;
 
 /// Klasa enkapsulująca połączenie z klientem.
@@ -347,6 +49,7 @@ public:
      * Klasa obsługująca zapytanie ma rolę menedżera.
      */
     Connection(Tcp::Socket socket, HandlerStrategy& handler);
+    ~Connection();
 
     /// Otwiera połączenie.
     void start();
@@ -366,10 +69,12 @@ private:
 
     BufferType buffer;
 
-    Tcp::Socket socket;
     HandlerStrategy& globalHandler;
-    RequestParser parser;
-    Request request;
+    struct ConnectionPimpl;
+    std::unique_ptr<ConnectionPimpl> pimpl;
+    //Tcp::Socket socket;
+    //RequestParser parser;
+    //Request request;
 };
 
 /// Klasa odpowiedzialna za rozdział zadań do odpowiednich wątków.
@@ -428,7 +133,7 @@ public:
      */
     virtual void handle(ConnectionResponse response) = 0;
     /// Bezpośrednio wysyła odpowiedź do gniazda.
-    virtual void respond(Tcp::Socket& socket, Response::Status stockResponse) = 0;
+    virtual void respond(Tcp::Socket& socket, ResponseStatus stockResponse) = 0;
 
     /// Uruchamia połączenie.
     virtual void start(ConnectionPtr connection) = 0;
@@ -448,7 +153,7 @@ public:
     /// Przekazuje zadanie do oddzielnego wątku.
     void handle(ConnectionResponse response) override;
     /// Odpowiada na głównym wątku.
-    void respond(Tcp::Socket& socket, Response::Status stockResponse) override;
+    void respond(Tcp::Socket& socket, ResponseStatus stockResponse) override;
 
     /// Implementuje HandlerStrategy.
     void start(ConnectionPtr connection) override;
@@ -483,8 +188,9 @@ public:
      * @param handler funkcja lub obiekt funkcyjny obsługujący argument Http::Request i zwracający Http::Response.
      * Obiekt wykorzystuje domyślną strategię ThreadedHandlerStrategy.
      */
-    Server(const std::string& host, const std::string& port, RequestHandler handler, ServicePtr service = ServicePtr(new Tcp::StreamService()));
-
+    Server(const std::string& host, const std::string& port, RequestHandler handler, ServicePtr service);
+    Server(const std::string& host, const std::string& port, RequestHandler handler);
+    ~Server();
     /// Uruchamia serwer.
     /**
      * Serwer będzie działać do czasu otrzymania sygnału przerwania systemowego.
@@ -496,9 +202,12 @@ private:
     /// asynchronicznie akceptuje połączenie.
     void accept();
 
-    ServicePtr service;
-    Tcp::Acceptor acceptor;
-    Tcp::SignalSet signals;
+    struct ServerPimpl;
+    std::unique_ptr<ServerPimpl> pimpl;
+
+    //ServicePtr service;
+    //Tcp::Acceptor acceptor;
+    //Tcp::SignalSet signals;
     StrategyPtr globalHandler;
 };
 

--- a/source/httpserver/ServerUtilities.h
+++ b/source/httpserver/ServerUtilities.h
@@ -1,0 +1,315 @@
+#ifndef PATR_SERVER_UTILITIES_H
+#define PATR_SERVER_UTILITIES_H
+
+#include <unordered_map>
+#include <string>
+
+
+namespace Http {
+
+/// Stała określająca nową linie wykorzystywaną przez HTTP.
+constexpr auto CRLF = "\r\n";
+/// Separator nagłówków HTTP.
+constexpr auto HEADER_SEPARATOR = ": ";
+
+
+
+
+/// Klasa określająca URI.
+/**
+* Pozwala na dekodowanie, tokenizację i segmentację oraz szeregowanie
+* subdomen, katalogów, zapytań GET.
+*/
+class Uri
+{
+public:
+    typedef std::unordered_map<std::string, std::string> QueryType;
+
+    /// Przeprowadza dekodowanie z formatu HTTP.
+    static bool Decode(const std::string& in, std::string& out);
+
+    /// Tworzy nowy URI z podanego łańcucha znaków.
+    Uri(const std::string& uri);
+    /// Tworzy pusty URI.
+    Uri();
+
+    /// Zwraca surowy łańcuch znaków w postaci, w jakiej je otrzymał.
+    std::string& raw();
+    const std::string& raw() const;
+    /// Zwraca argumenty zapytania GET
+    /**
+    * Tokenizacja przebiega po pierwszym znaku '?',
+    * rodzielona '&' oraz '='.
+    * Elementy nie są dekodowane.
+    */
+    QueryType query() const;
+    /// Zwraca rodzica katalogu.
+    /**
+    * Dla /foo/bar/ zwraca /foo/bar
+    * Dla /foo/bar zwraca /foo
+    * Elementy nie są dekodowane.
+    */
+    Uri parent() const;
+    /// Zwraca ścieżkę bez argumentów GET.
+    /**
+    * Ścieżka nie jest dekodowana.
+    */
+    Uri absolutePath() const;
+    /// Rozdziela ścieżkę absolutną na poszczególne katalogi.
+    /**
+    * Segmenty nie są dekodowane.
+    */
+    std::vector<std::string> segments() const;
+
+private:
+    std::string uri;
+};
+
+
+
+/// Typ wykorzystywany jako ciało dokumentu HTTP.
+typedef std::string BodyType;
+/// Typ wykorzystywany jako oznaczenie typu MIME.
+typedef std::string MediaType;
+
+
+
+/// Posiada dostępne domyślne metody HTTP.
+namespace RequestMethod
+{
+    constexpr auto OPTIONS = "OPTIONS";
+    constexpr auto GET = "GET";
+    constexpr auto HEAD = "HEAD";
+    constexpr auto POST = "POST";
+    constexpr auto PUT = "PUT";
+    constexpr auto TRACE = "TRACE";
+    constexpr auto CONNECT = "CONNECT";
+    constexpr auto DELETE = "DELETE";
+}
+
+
+
+/// Struktura określająca wersję HTTP.
+struct Version
+{
+    int major, minor;
+};
+
+
+
+/// Typ wykorzystywany do reprezentacji Nagłówka.
+typedef std::pair<std::string /* name */, std::string /* value */> Header;
+/// Typ wykorzystywany do kolekcji nagłówków.
+//typedef std::unordered_map<Header::first_type, Header::second_type> HeaderContainer;
+typedef std::vector<Header> HeaderContainer;
+
+
+
+/// Klasa określająca zapytanie HTTP.
+class Request
+{
+public:
+    /// Zwraca ciąg znaków, jaki otrzymany był w zapytaniu.
+    std::string raw() const;
+    /// Zwraca metodę HTTP.
+    const std::string& method() const;
+    /// Zwraca URI.
+    const Uri& uri() const;
+    /// Zwraca wersję w formacie {}.{}
+    std::string version() const;
+    /// Zwraca kolekcję wszystkich nagłówków.
+    const HeaderContainer& headers() const;
+    /// Zwraca ciało dokumentu.
+    const BodyType& body() const;
+
+private:
+    /// Posiada informacje szczegółowe o główynm wierszu.
+    struct RequestLine
+    {
+        std::string method;
+        Uri uri;
+        Version version;
+    } requestLine;
+
+    HeaderContainer headerCollection;
+    BodyType content;
+
+    friend class RequestParser;
+};
+
+
+
+/// Parser zapytań HTTP.
+/**
+* Jest maszyną stanów w celu optymalizacji asynchronicznego odczytywania zapytań.
+*/
+class RequestParser
+{
+public:
+    /// Wynik parsowania.
+    enum class Result
+    {
+        Good, //< Zapytanie poprawne pod względem syntaktycznym.
+        Bad, //< Zapytanie niepoprawne pod względem syntaktycznym.
+        Indeterminate //< Zapytanie dotychczas nie zawierało błędów syntaktycznych.
+    };
+
+    /// Tworzy nowy obiekt.
+    RequestParser();
+
+    /// Przeprowadza parsowanie dla podanego zasięgu.
+    /**
+    * Kontener musi mieć value_type == char lub kompatybilny i
+    * możliwość dostępu sekwencyjnego.
+    */
+    template<typename InputIt>
+    std::pair<Result, InputIt> parse(InputIt begin, InputIt end, Request& request)
+    {
+        while (begin != end)
+        {
+            Result result = consume(*begin++, request);
+            if (result == Result::Good || result == Result::Bad)
+                return std::make_pair(result, begin);
+        }
+        return std::make_pair(Result::Indeterminate, begin);
+    }
+
+    /// Dodaje do ciała zapytania dany zasięg.
+    /**
+    * Przeprowadza sprawdzenie z nagłówkiem Content-Length w celu
+    * okreslenia maksymalnej wielkości ciała zapytania.
+    */
+    template<typename InputIt>
+    static bool fill(InputIt begin, InputIt end, Request& request)
+    {
+        std::size_t max = contentLength(request);
+
+        if (request.content.length() == max)
+            return true;
+
+        while (begin != end)
+        {
+            request.content += *begin++;
+            if (request.content.length() == max)
+                return true;
+        }
+        return false;
+    }
+
+    void reset();
+
+private:
+    /// Zwraca długość ciała dla zapytania HTTP.
+    static int contentLength(const Request& request);
+    /// Sprawdza zgodność znaku w danej chwili dla zapytania.
+    Result consume(char value, Request& request);
+
+    /// Lista możliwych stanów parsera.
+    enum State
+    {
+        MethodStart,
+        Method,
+        Uri,
+        HttpVersionH,
+        HttpVersionT1,
+        HttpVersionT2,
+        HttpVersionP,
+        HttpVersionSlash,
+        HttpVersionMajorStart,
+        HttpVersionMajor,
+        HttpVersionMinorStart,
+        HttpVersionMinor,
+        ExpectingNewline1,
+        HeaderLineStart,
+        HeaderLws,
+        HeaderName,
+        SpaceBeforeHeaderValue,
+        HeaderValue,
+        ExpectingNewline2,
+        ExpectingNewline3
+    } state;
+};
+
+/// Lista możliwych statusów odpowiedzi wraz z odpowiadającymi kodami.
+enum class ResponseStatus
+{
+    /* Informational */
+    Continue = 100,
+    SwitchingProtocols = 101,
+
+    /* Success */
+    Ok = 200,
+    Created = 201,
+    Accepted = 202,
+    NonAuthoritativeInformation = 203,
+    NoContent = 204,
+    ResetContent = 205,
+    PartialContent = 206,
+
+    /* Redirection */
+    MultipleChoices = 300,
+    MovedPermanently = 301,
+    Found = 302,
+    SeeOther = 303,
+    NotModified = 304,
+    UseProxy = 305,
+    TemporaryRedirect = 307,
+
+    /* Client Error */
+    BadRequest = 400,
+    Unauthorized = 401,
+    PaymentRequired = 402,
+    Forbidden = 403,
+    NotFound = 404,
+    MethodNotAllowed = 405,
+    NotAcceptable = 406,
+    ProxyAuthenticationRequired = 407,
+    RequestTimeout = 408,
+    Conflict = 409,
+    Gone = 410,
+    LengthRequired = 411,
+    PreconditionFailed = 412,
+    RequestEntityTooLarge = 413,
+    RequestUriTooLarge = 414,
+    UnsupportedMediaType = 415,
+    RequestedRangeNotSatisfiable = 416,
+    ExpectationFailed = 417,
+
+    /* Server Error */
+    InternalServerError = 500,
+    NotImplemented = 501,
+    BadGateway = 502,
+    ServiceUnavailable = 503,
+    GatewayTimeout = 504,
+    HttpVersionNotSupported = 505
+};
+
+
+/// Klasa odpowiedzi HTTP.
+class Response
+{
+public:
+
+    /// Tworzy odpowiedź z danym kodem i ciałem o podanym typie mediów.
+    Response(ResponseStatus code, const BodyType& content, const MediaType& mediaType);
+
+    /// Zwraca odpowiedź w formie, jaka zostanie wysłana do klienta.
+    std::string raw() const;
+    /// Zwraca status odpowiedzi.
+    ResponseStatus status() const;
+
+    /// Posiada nagłówki możliwe do modyfikacji w zależności od potrzeb.
+    /**
+    * Nagłówki nie przechodzą walidacji syntaktycznej.
+    */
+    HeaderContainer headers;
+
+private:
+    ResponseStatus responseStatus;
+    std::string response;
+};
+
+
+} // namespace Http
+
+#endif // PATR_SERVER_UTILITIES_H

--- a/source/httpserver/ServerUtilities.h
+++ b/source/httpserver/ServerUtilities.h
@@ -290,6 +290,8 @@ class Response
 {
 public:
 
+    using Status = ResponseStatus;
+
     /// Tworzy odpowiedź z danym kodem i ciałem o podanym typie mediów.
     Response(ResponseStatus code, const BodyType& content, const MediaType& mediaType);
 

--- a/source/httpserver/test/HttpTest.cpp
+++ b/source/httpserver/test/HttpTest.cpp
@@ -2,6 +2,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include "../Server.h"
+#include "../ServerUtilities.h"
 #include "../Socket.h"
 
 /// Testy sprawdzające poprawność parsera zapytań HTTP.
@@ -82,10 +83,10 @@ BOOST_AUTO_TEST_CASE(ResponseContents)
 {
     std::string content = "Content\n\t\n\n   \\\"; ";
     std::string type = "text/plain";
-    Http::Response response(Http::Response::Status::Ok, content, type);
+    Http::Response response(Http::ResponseStatus::Ok, content, type);
     BOOST_CHECK(response.headers[0].first == "Content-Length" && response.headers[0].second == std::to_string(content.length()));
     BOOST_CHECK(response.headers[1].first == "Content-Type" && response.headers[1].second == type);
-    BOOST_CHECK(response.status() == Http::Response::Status::Ok);
+    BOOST_CHECK(response.status() == Http::ResponseStatus::Ok);
 }
 
 BOOST_AUTO_TEST_SUITE_END()
@@ -194,7 +195,7 @@ BOOST_AUTO_TEST_CASE(ConnectionHandlerCall)
         Http::ThreadedHandlerStrategy handler([&called](const Http::Request& request)
         {
             called = true;
-            return Http::Response(Http::Response::Status::Ok, "", "");
+            return Http::Response(Http::ResponseStatus::Ok, "", "");
         }
         );
 
@@ -214,7 +215,7 @@ BOOST_AUTO_TEST_CASE(MultipleConnections)
         Http::ThreadedHandlerStrategy handler([](const Http::Request& request)
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            return Http::Response(Http::Response::Status::Ok, "", "");
+            return Http::Response(Http::ResponseStatus::Ok, "", "");
         }
         );
         for (int i = 0; i < 12; ++i)
@@ -233,7 +234,7 @@ BOOST_AUTO_TEST_CASE(ConnectionValidity)
     using Http::CRLF;
     ServiceMock service;
     std::ostringstream globalWriter;
-    Http::Response response(Http::Response::Status::Ok, "Content\n\t\n\n   \\\"; ", "text/plain");
+    Http::Response response(Http::ResponseStatus::Ok, "Content\n\t\n\n   \\\"; ", "text/plain");
     auto socket = std::unique_ptr<Tcp::SocketInterface>(new SocketMock(std::string("GET / HTTP/1.0") + CRLF + CRLF, service, nullptr, &globalWriter));
     {
         Http::ThreadedHandlerStrategy handler([&response](const Http::Request& request)
@@ -261,7 +262,7 @@ BOOST_AUTO_TEST_CASE(ConnectionSendClosed)
     {
         Http::ThreadedHandlerStrategy handler([](const Http::Request& request)
         {
-            return Http::Response(Http::Response::Status::Ok, "", "");
+            return Http::Response(Http::ResponseStatus::Ok, "", "");
         }
         );
 
@@ -280,7 +281,7 @@ BOOST_AUTO_TEST_CASE(ConnectionClose)
     BOOST_CHECK(!isClosed);
     {
         Http::ThreadedHandlerStrategy handler([](const Http::Request& request)
-        { return Http::Response(Http::Response::Status::Ok, "", ""); }
+        { return Http::Response(Http::ResponseStatus::Ok, "", ""); }
         );
 
         BOOST_REQUIRE_NO_THROW(

--- a/source/request_router/RequestRouter.cpp
+++ b/source/request_router/RequestRouter.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 #include "RequestRouter.h"
-#include "../httpserver/Server.h"
+#include "../httpserver/ServerUtilities.h"
 
 
 namespace Router
@@ -13,7 +13,7 @@ namespace Router
         if (func == services.end())
         {
             return Http::Response(
-                Http::Response::Status::NotFound,
+                Http::ResponseStatus::NotFound,
                 R"({"error":"no service for )" + request.uri().raw() + R"("})",
                 "application/json");
         }
@@ -26,7 +26,7 @@ namespace Router
             std::tie(body, response_code) = func->second(request.body());
            
             return Http::Response(
-                static_cast<Http::Response::Status>(response_code),
+                static_cast<Http::ResponseStatus>(response_code),
                 body,
                 "application/json");
         }
@@ -38,7 +38,7 @@ namespace Router
                           << std::endl;
 
             return Http::Response(
-                Http::Response::Status::InternalServerError,
+                Http::ResponseStatus::InternalServerError,
                 R"({"error":"internal server error"})",
                 "application/json");
         }

--- a/source/request_router/RequestRouter.cpp
+++ b/source/request_router/RequestRouter.cpp
@@ -13,7 +13,7 @@ namespace Router
         if (func == services.end())
         {
             return Http::Response(
-                Http::ResponseStatus::NotFound,
+                Http::Response::Status::NotFound,
                 R"({"error":"no service for )" + request.uri().raw() + R"("})",
                 "application/json");
         }
@@ -26,7 +26,7 @@ namespace Router
             std::tie(body, response_code) = func->second(request.body());
            
             return Http::Response(
-                static_cast<Http::ResponseStatus>(response_code),
+                static_cast<Http::Response::Status>(response_code),
                 body,
                 "application/json");
         }
@@ -38,7 +38,7 @@ namespace Router
                           << std::endl;
 
             return Http::Response(
-                Http::ResponseStatus::InternalServerError,
+                Http::Response::Status::InternalServerError,
                 R"({"error":"internal server error"})",
                 "application/json");
         }

--- a/source/request_router/RequestRouter.h
+++ b/source/request_router/RequestRouter.h
@@ -4,13 +4,7 @@
 #include <map>
 #include <string>
 #include <functional>
-
-
-namespace Http
-{
-    class Request;
-    class Response;
-}
+#include "../httpserver/ServerUtilities.h"
 
 namespace Router
 {


### PR DESCRIPTION
Pozwoli to na m.in. skrócenie czasu kompilacji. W ServerUtilities.h znajdują się deklaracje klas Http::Request, Http::Response, Http::RequestParser, Http::ResponseStatus (dodany alias Http::Response::Status w celu uniknięcia zmiany interfejsu).