### PR TITLE
Rozszerzenie konstruktora ThreadedHandlerStrategy

### DIFF
--- a/source/httpserver/Server.cpp
+++ b/source/httpserver/Server.cpp
@@ -187,7 +187,7 @@ void Http::Connection::write()
     globalHandler.stop(shared_from_this());
 }
 
-Http::ThreadedHandlerStrategy::ThreadedHandlerStrategy(RequestHandler handler) : handler(handler)
+Http::ThreadedHandlerStrategy::ThreadedHandlerStrategy(RequestHandler handler, std::size_t maxRequests, std::size_t nThreads) : handler(handler), pool(nThreads ? nThreads : std::thread::hardware_concurrency(), maxRequests)
 {
 }
 

--- a/source/httpserver/Server.h
+++ b/source/httpserver/Server.h
@@ -148,8 +148,11 @@ public:
 class ThreadedHandlerStrategy : public HandlerStrategy
 {
 public:
-
-    ThreadedHandlerStrategy(RequestHandler handler);
+    /// Tworzy obiekt obsługujący kolejkę maxRequests zapytań za pomocą podanej funkcji na nThreads wątkach.
+    /**
+     * @param nThreads wartość 0 ustawia liczbę wątków równą wykrytej liczbie procesorów.
+     */
+    ThreadedHandlerStrategy(RequestHandler handler, std::size_t maxRequests = 5000U,  std::size_t nThreads = 0U);
 
     /// Przekazuje zadanie do oddzielnego wątku.
     void handle(ConnectionResponse response) override;


### PR DESCRIPTION
Pozwala na ustalenie liczby wątków oraz maksymalnej wielkości kolejki zapytań. Wcześniej ta konfiguracja była ograniczona przez ten konstruktor. Obecnie tworzone jest tyle wątków ile program wykrywa procesorów funkcją ```std::thread::hardware_concurrency()```.
Inna rzecz która jest zakodowana "na twardo" to timeout na bezczynność klienta po połączeniu bez otrzymania pełnego zapytania (obecnie wynosi 30s). Jeżeli jest taka potrzeba mogę to również sparametryzować.