### PR TITLE
Json - gettery dla pierwszego klucza i wartości

### DIFF
--- a/source/json/Json.cpp
+++ b/source/json/Json.cpp
@@ -495,7 +495,7 @@ Json::const_iterator Json::cend() const
 }
 
 // Metoda zwraca pierwszy klucz obiektu
-std::string Json::getKey() const
+const std::string& Json::getKey() const
 {
     if (!isObject())
         throw std::domain_error("invalid type");
@@ -503,17 +503,23 @@ std::string Json::getKey() const
 }
 
 // Metoda zwraca pierwszą wartość obiektu
-Json Json::getValue() const
+Json& Json::getValue()
 {
     switch (type)
     {
     case Type::Array:
-        return *value.array->cbegin();
+        return *value.array->begin();
     case Type::Object:
-        return value.object->cbegin()->second;
+        return value.object->begin()->second;
     default:
         throw std::domain_error("invalid type");
     }
+}
+
+// Metoda zwraca pierwszą wartość obiektu
+const Json& Json::getValue() const
+{
+    return const_cast<Json*>(this)->getValue();
 }
 
 // Metoda zwraca typ obiektu

--- a/source/json/Json.cpp
+++ b/source/json/Json.cpp
@@ -494,6 +494,28 @@ Json::const_iterator Json::cend() const
     }
 }
 
+// Metoda zwraca pierwszy klucz obiektu
+std::string Json::getKey() const
+{
+    if (!isObject())
+        throw std::domain_error("invalid type");
+    return value.object->cbegin()->first;
+}
+
+// Metoda zwraca pierwszą wartość obiektu
+Json Json::getValue() const
+{
+    switch (type)
+    {
+    case Type::Array:
+        return *value.array->cbegin();
+    case Type::Object:
+        return value.object->cbegin()->second;
+    default:
+        throw std::domain_error("invalid type");
+    }
+}
+
 // Metoda zwraca typ obiektu
 const Json::Type Json::getType() const
 {

--- a/source/json/Json.hpp
+++ b/source/json/Json.hpp
@@ -248,10 +248,13 @@ public:
     const_iterator cend() const;
 
     // Metoda zwraca pierwszy klucz obiektu
-    std::string getKey() const;
+    const std::string& getKey() const;
 
     // Metoda zwraca pierwszą wartość obiektu
-    Json getValue() const;
+    Json& getValue();
+
+    // Metoda zwraca pierwszą wartość obiektu
+    const Json& getValue() const;
 
     // Metoda zwraca typ obiektu
     const Type getType() const;

--- a/source/json/Json.hpp
+++ b/source/json/Json.hpp
@@ -247,6 +247,12 @@ public:
     // Metoda zwraca stały iterator na koniec kontenera
     const_iterator cend() const;
 
+    // Metoda zwraca pierwszy klucz obiektu
+    std::string getKey() const;
+
+    // Metoda zwraca pierwszą wartość obiektu
+    Json getValue() const;
+
     // Metoda zwraca typ obiektu
     const Type getType() const;
 

--- a/source/ocr/Ocr.cpp
+++ b/source/ocr/Ocr.cpp
@@ -69,9 +69,9 @@ void Ocr::fixErrors(std::string& text) const
 
     for (const Json& entry : dict)
     {
-        const std::string& fix = entry.cbegin().key();
+        const std::string& fix = entry.getKey();
 
-        for (const std::string& err : entry.cbegin().value())
+        for (const std::string& err : entry.getValue())
         {
             for (size_t pos = text.find(err); pos != end; pos = text.find(err))
             {


### PR DESCRIPTION
Zmiana ma na celu uniknięcie wykorzystania iteratora dla pozyskania klucza lub wartości pierwszego elementu obiektu np. *json.cbegin() lub json.cbegin().value(), jest równoważne json.getValue().