### PR TITLE
Miso studybox 496 premake all

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -1,3 +1,163 @@
+-- Helper functions --
+
+PROJ_ROOT = path.getabsolute('.');
+
+setup = {}
+action = {}
+action.vs = {}
+action.os = {}
+setup.nuget = {}
+setup.linux = {}
+
+function action.os.type()
+    if string.find(_ACTION, 'vs[0-9]*') then
+        return 'windows'
+    elseif
+        _ACTION == 'gmake' or
+        _ACTION == 'monodevelop' or
+        _ACTION == 'codelite' or
+        _ACTION == 'xcode4' then
+        return 'linux'
+    else
+        return 'unknown'
+    end
+end
+
+function action.vs.toolset()
+    local toolset =
+        _ACTION == 'vs2015' and '140' or
+        _ACTION == 'vs2013' and '120' or
+        _ACTION == 'vs2012' and '110' or
+        _ACTION == 'vs2010' and '100' or
+        _ACTION == 'vs2008' and '90'
+    return toolset
+end
+
+-- Setup functions --
+
+function setup.nuget.packages()
+    local file = assert(io.open('build/studybox_cv/packages.config', 'w'))
+    local config =
+      [[<?xml version="1.0" encoding="utf-8"?>
+        <packages>
+            <package id="boost" version="1.60.0.0" targetFramework="native"/>
+            <package id="boost_unit_test_framework-vc140" version="1.60.0.0" targetFramework="native"/>
+            <package id="opencv3.1" version="1.0" targetFramework="native"/>
+            <package id="opencv3.1.redist" version="1.0" targetFramework="native"/>
+            <package id="leptonica" version="1.73" targetFramework="native" />
+            <package id="leptonica-vc140" version="1.73" targetFramework="native" />
+            <package id="tesseract" version="3.04" targetFramework="native" />
+            <package id="tesseract-vc140" version="3.04" targetFramework="native" />
+        </packages>]]
+    file:write(config)
+    file:close()
+end
+
+function setup.nuget.config()
+    local file = assert(io.open('build/nuget.config', 'w'))
+    local path = string.gsub(os.getcwd(), '/', '\\')..'\\3rdparty\\'
+    local config =
+      [[<?xml version="1.0" encoding="utf-8"?>
+        <configuration>
+        <disabledPackageSources>
+            <add key="Microsoft and .NET" value="true" />
+        </disabledPackageSources>
+        <packageRestore>
+            <add key="enabled" value="True" />
+            <add key="automatic" value="True" />
+        </packageRestore>
+        <bindingRedirects>
+            <add key="skip" value="False" />
+        </bindingRedirects>
+        <packageSources>
+            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+            <add key="studyboxcv" value="]]..path..[[" />
+        </packageSources>
+        <activePackageSource>
+            <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+        </activePackageSource>
+        </configuration>]]
+    file:write(config)
+    file:close()
+end
+
+function setup.linux.opencv()
+    if os.execute('sudo stat /usr/local/lib/libopencv_core.so.3.1.0 > /dev/null 2>&1') ~= 0 then
+        print('Setting up "OpenCV"')
+        local tmp = os.tmpname()
+        local file = assert(io.open(tmp, 'w'))
+        file:write([[
+            #!/bin/bash
+            set -e
+            apt-get --yes update
+            apt-get --yes --force-yes install build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
+            cd /opt ; wget -O opencv.tar.gz https://github.com/Itseez/opencv/archive/3.1.0.tar.gz
+            mkdir opencv ; tar -zxvf opencv.tar.gz -C opencv --strip-components 1
+            cd opencv
+            mkdir -p 3rdparty/ippicv/downloads/linux-808b791a6eac9ed78d32a7666804320e
+            wget -P 3rdparty/ippicv/downloads/linux-808b791a6eac9ed78d32a7666804320e/ https://raw.githubusercontent.com/Itseez/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_linux_20151201.tgz
+            for config in debug release
+            do
+                mkdir $config ; cd $config
+                cmake -D CMAKE_BUILD_TYPE=$config -D CMAKE_INSTALL_PREFIX=/usr/local ..
+                make ; make install ; cd ..
+            done
+            ldconfig
+        ]])
+        file:close()
+        os.execute('sudo chmod +x '..tmp..'; sudo '..tmp)
+        os.execute('sudo rm -rf /opt/opencv /opt/opencv.tar.gz '..tmp)
+    end
+end
+
+function setup.linux.boost()
+    if os.execute('sudo stat /usr/local/lib/libboost_unit_test_framework.so.1.60.0 > /dev/null 2>&1') ~= 0 then
+        print('Setting up "Boost"')
+        local tmp = os.tmpname()
+        local file = assert(io.open(tmp, 'w'))
+        file:write([[
+            #!/bin/bash
+            set -e
+            apt-get --yes update
+            apt-get --yes --force-yes install build-essential cmake git p7zip-full
+            cd /opt ; wget -O boost.tar.gz https://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.tar.gz
+            mkdir boost ; tar -zxvf boost.tar.gz -C boost --strip-components 1
+            cd boost
+            ./bootstrap.sh -with-libraries=test,log,random,thread,locale,regex,filesystem,date_time
+            ./b2 install
+            ldconfig
+        ]])
+        file:close()
+        os.execute('sudo chmod +x '..tmp..'; sudo '..tmp)
+        os.execute('sudo rm -rf /opt/boost /opt/boost.tar.gz '..tmp)
+    end
+end
+
+function setup.linux.tesseract()
+    if os.execute('sudo stat /usr/local/lib/libtesseract.so > /dev/null 2>&1') ~= 0 then
+        print('Setting up "Tesseract"')
+        local tmp = os.tmpname()
+        local file = assert(io.open(tmp, 'w'))
+        file:write([[
+            #!/bin/bash ; set -e
+            apt-get --yes --force-yes --assume-yes install autoconf automake libtool libpng12-dev libjpeg62-dev libtiff5-dev zlib1g-dev
+            cd /opt ; wget http://www.leptonica.com/source/leptonica-1.73.tar.gz -O leptonica.tar.gz
+            mkdir leptonica ; tar -zxvf leptonica.tar.gz -C leptonica --strip-components 1
+            cd leptonica
+            ./configure ; make ; make install
+            cd .. ; wget https://github.com/tesseract-ocr/tesseract/archive/3.04.01.tar.gz -O tesseract.tar.gz
+            mkdir tesseract ; tar -zxvf tesseract.tar.gz -C tesseract --strip-components 1
+            cd tesseract
+            ./autogen.sh ; ./configure ; make ; make install ; ldconfig
+            cd / ; rm -rf /opt/tesseract /opt/leptonica "$0"
+        ]])
+        file:close()
+        os.execute('sudo chmod +x '..tmp..'; sudo '..tmp)
+    end
+end
+
+-- Premake rules --
+
 workspace 'StudyBox_CV'
     location 'build'
     flags 'FatalWarnings'
@@ -16,10 +176,10 @@ workspace 'StudyBox_CV'
         defines 'NDEBUG'
 
     filter 'action:vs*'
-        defines { 'WIN32', 'NOMINMAX', 'NOGDI', 'ABSOLUTE_PATH="'..path.getabsolute('.')..'"' }
+        defines { 'WIN32', 'NOMINMAX', 'NOGDI', 'ABSOLUTE_PATH="'..PROJ_ROOT..'"' }
     filter 'action:not vs*'
         buildoptions '-std=c++0x'
-        defines { 'ABSOLUTE_PATH=\\"'..path.getabsolute('.')..'\\"' }
+        defines { 'ABSOLUTE_PATH=\\"'..PROJ_ROOT..'\\"' }
 
     project 'StudyBox_CV'
         language 'C++'
@@ -33,40 +193,14 @@ workspace 'StudyBox_CV'
             '**/example.cpp'
         }
 
-        filter 'test'
-            kind 'ConsoleApp'
         filter { 'not test', 'files:**/test/** or files:**maintest.cpp' }
             flags 'ExcludeFromBuild'
         filter { 'test', 'files:**main.cpp' }
             flags 'ExcludeFromBuild'
         filter '*'
 
-        if _ACTION and string.find(_ACTION, 'vs*') then
-            local toolset = _ACTION == 'vs2015' and '140' or
-                            _ACTION == 'vs2013' and '120' or
-                            _ACTION == 'vs2012' and '110' or
-                            _ACTION == 'vs2010' and '100' or
-                            _ACTION == 'vs2008' and '90'
-
-            includedirs {
-                'build/packages/opencv3.1.1.0/build/native/include',
-                'build/packages/boost.1.60.0.0/lib/native/include',
-                'build/packages/leptonica.1.73/lib/native/include',
-                'build/packages/tesseract.3.04/lib/native/include'
-            }
-            libdirs {
-                'build/packages/opencv3.1.1.0/build/native/lib/%{cfg.platform}/v'..toolset..'/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}',
-                'build/packages/boost_unit_test_framework-vc'..toolset..'.1.60.0.0/lib/native/address-model-%{string.sub(cfg.platform, -2)}/lib',
-                'build/packages/leptonica-vc'..toolset..'.1.73/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}',
-                'build/packages/tesseract-vc'..toolset..'.3.04/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}'
-            }
-            debugenvs {
-                'PATH=%PATH%;'..
-                '../packages/opencv3.1.redist.1.0/build/native/bin/%{cfg.platform}/v'..toolset..'/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg};'..
-                '../packages/boost_unit_test_framework-vc'..toolset..'.1.60.0.0/lib/native/address-model-%{string.sub(cfg.platform, -2)}/lib;'..
-                '../packages/leptonica-vc'..toolset..'.1.73/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg};'..
-                '../packages/tesseract-vc'..toolset..'.3.04/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}'
-            }
+        if action.os.type() == 'windows' then
+            local toolset = action.vs.toolset()
 
             filter '*'
                 links {
@@ -85,6 +219,28 @@ workspace 'StudyBox_CV'
                 links {
                     'boost_unit_test_framework-vc'..toolset..'-mt-1_60'
                 }
+            filter '*'
+
+            includedirs {
+                'build/packages/opencv3.1.1.0/build/native/include',
+                'build/packages/boost.1.60.0.0/lib/native/include',
+                'build/packages/leptonica.1.73/lib/native/include',
+                'build/packages/tesseract.3.04/lib/native/include'
+            }
+
+            libdirs {
+                'build/packages/opencv3.1.1.0/build/native/lib/%{cfg.platform}/v'..toolset..'/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}',
+                'build/packages/boost_unit_test_framework-vc'..toolset..'.1.60.0.0/lib/native/address-model-%{string.sub(cfg.platform, -2)}/lib',
+                'build/packages/leptonica-vc'..toolset..'.1.73/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}',
+                'build/packages/tesseract-vc'..toolset..'.3.04/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}'
+            }
+            debugenvs {
+                'PATH=%PATH%;'..
+                '../packages/opencv3.1.redist.1.0/build/native/bin/%{cfg.platform}/v'..toolset..'/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg};'..
+                '../packages/boost_unit_test_framework-vc'..toolset..'.1.60.0.0/lib/native/address-model-%{string.sub(cfg.platform, -2)}/lib;'..
+                '../packages/leptonica-vc'..toolset..'.1.73/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg};'..
+                '../packages/tesseract-vc'..toolset..'.3.04/lib/native/%{cfg.platform == "Win32" and "x86" or "x64"}/%{cfg.buildcfg == "Test" and "Release" or cfg.buildcfg}'
+            }
 
             filter 'test'
                 postbuildcommands {
@@ -95,53 +251,10 @@ workspace 'StudyBox_CV'
                     '"$(TargetDir)\\$(TargetName).exe" --result_code=no --report_level=short'
                 }
 
-            local file = assert(io.open('build/studybox_cv/packages.config', 'w'))
-            local config =
-              [[<?xml version="1.0" encoding="utf-8"?>
-                <packages>
-                    <package id="boost" version="1.60.0.0" targetFramework="native"/>
-                    <package id="boost_unit_test_framework-vc140" version="1.60.0.0" targetFramework="native"/>
-                    <package id="opencv3.1" version="1.0" targetFramework="native"/>
-                    <package id="opencv3.1.redist" version="1.0" targetFramework="native"/>
-                    <package id="leptonica" version="1.73" targetFramework="native" />
-                    <package id="leptonica-vc140" version="1.73" targetFramework="native" />
-                    <package id="tesseract" version="3.04" targetFramework="native" />
-                    <package id="tesseract-vc140" version="3.04" targetFramework="native" />
-                </packages>]]
-            file:write(config)
-            file:close()
+            setup.nuget.config()
+            setup.nuget.packages()
 
-            local file = assert(io.open('build/nuget.config', 'w'))
-            local path = string.gsub(os.getcwd(), '/', '\\')..'\\3rdparty\\'
-            local config =
-              [[<?xml version="1.0" encoding="utf-8"?>
-                <configuration>
-                <disabledPackageSources>
-                    <add key="Microsoft and .NET" value="true" />
-                </disabledPackageSources>
-                <packageRestore>
-                    <add key="enabled" value="True" />
-                    <add key="automatic" value="True" />
-                </packageRestore>
-                <bindingRedirects>
-                    <add key="skip" value="False" />
-                </bindingRedirects>
-                <packageSources>
-                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-                    <add key="studyboxcv" value="]]..path..[[" />
-                </packageSources>
-                <activePackageSource>
-                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-                </activePackageSource>
-                </configuration>]]
-                file:write(config)
-                file:close()
-        end
-
-        if _ACTION == 'gmake' or
-           _ACTION == 'monodevelop' or
-           _ACTION == 'codelite' or
-           _ACTION == 'xcode4' then
+        elseif action.os.type() == 'linux' then
             includedirs {
                 'usr/local/include'
             }
@@ -151,89 +264,59 @@ workspace 'StudyBox_CV'
             links {
                 'ssl',
                 'crypto',
+                'pthread',
+                'tesseract',
                 'opencv_core',
+                'boost_system',
                 'opencv_imgproc',
                 'opencv_highgui',
-                'opencv_imgcodecs',
-                'boost_system',
-                'pthread',
-                'tesseract'
+                'opencv_imgcodecs'
             }
             filter 'test'
                 links {
                     'boost_unit_test_framework'
                 }
-
-            if os.execute('sudo stat /usr/local/lib/libopencv_core.so.3.1.0 > /dev/null 2>&1') ~= 0 then
-                print('Setting up "OpenCV"')
-                local tmp = os.tmpname()
-                local file = assert(io.open(tmp, 'w'))
-                file:write([[
-                    #!/bin/bash
-                    set -e
-                    apt-get --yes update
-                    apt-get --yes --force-yes install build-essential cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev python-dev python-numpy libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libjasper-dev libdc1394-22-dev
-                    cd /opt ; wget -O opencv.tar.gz https://github.com/Itseez/opencv/archive/3.1.0.tar.gz
-                    mkdir opencv ; tar -zxvf opencv.tar.gz -C opencv --strip-components 1
-                    cd opencv
-                    mkdir -p 3rdparty/ippicv/downloads/linux-808b791a6eac9ed78d32a7666804320e
-                    wget -P 3rdparty/ippicv/downloads/linux-808b791a6eac9ed78d32a7666804320e/ https://raw.githubusercontent.com/Itseez/opencv_3rdparty/81a676001ca8075ada498583e4166079e5744668/ippicv/ippicv_linux_20151201.tgz
-                    for config in debug release
-                    do
-                        mkdir $config ; cd $config
-                        cmake -D CMAKE_BUILD_TYPE=$config -D CMAKE_INSTALL_PREFIX=/usr/local ..
-                        make ; make install ; cd ..
-                    done
-                    ldconfig
-                ]])
-                file:close()
-                os.execute('sudo chmod +x '..tmp..'; sudo '..tmp)
-                os.execute('sudo rm -rf /opt/opencv /opt/opencv.tar.gz '..tmp)
-            end
-
-            if os.execute('sudo stat /usr/local/lib/libboost_unit_test_framework.so.1.60.0 > /dev/null 2>&1') ~= 0 then
-                print('Setting up "Boost"')
-                local tmp = os.tmpname()
-                local file = assert(io.open(tmp, 'w'))
-                file:write([[
-                    #!/bin/bash
-                    set -e
-                    apt-get --yes update
-                    apt-get --yes --force-yes install build-essential cmake git p7zip-full
-                    cd /opt ; wget -O boost.tar.gz https://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.tar.gz
-                    mkdir boost ; tar -zxvf boost.tar.gz -C boost --strip-components 1
-                    cd boost
-                    ./bootstrap.sh -with-libraries=test,log,random,thread,locale,regex,filesystem,date_time
-                    ./b2 install
-                    ldconfig
-                ]])
-                file:close()
-                os.execute('sudo chmod +x '..tmp..'; sudo '..tmp)
-                os.execute('sudo rm -rf /opt/boost /opt/boost.tar.gz '..tmp)
-            end
-
-            if os.execute('sudo stat /usr/local/lib/libtesseract.so > /dev/null 2>&1') ~= 0 then
-                print('Setting up "Tesseract"')
-                local tmp = os.tmpname()
-                local file = assert(io.open(tmp, 'w'))
-                file:write([[
-                    #!/bin/bash ; set -e
-                    apt-get --yes --force-yes --assume-yes install autoconf automake libtool libpng12-dev libjpeg62-dev libtiff5-dev zlib1g-dev
-                    cd /opt ; wget http://www.leptonica.com/source/leptonica-1.73.tar.gz -O leptonica.tar.gz
-                    mkdir leptonica ; tar -zxvf leptonica.tar.gz -C leptonica --strip-components 1
-                    cd leptonica
-                    ./configure ; make ; make install
-                    cd .. ; wget https://github.com/tesseract-ocr/tesseract/archive/3.04.01.tar.gz -O tesseract.tar.gz
-                    mkdir tesseract ; tar -zxvf tesseract.tar.gz -C tesseract --strip-components 1
-                    cd tesseract
-                    ./autogen.sh ; ./configure ; make ; make install ; ldconfig
-                    cd / ; rm -rf /opt/tesseract /opt/leptonica "$0"
-                ]])
-                file:close()
-                os.execute('sudo chmod +x '..tmp..'; sudo '..tmp)
-            end
-
+            setup.linux.boost()
+            setup.linux.opencv()
+            setup.linux.tesseract()
         end
+
+-- Premake overrides --
+
+premake.override(premake.main, 'postAction', function(base)
+    base()
+
+    if action.os.type() == 'linux' then
+
+    elseif action.os.type() == 'windows' then
+
+    end
+
+    if _OPTIONS['test'] then
+        print()
+        os.execute('"'..PROJ_ROOT..'/bin/x64/Test/StudyBox_CV"')
+    end
+end)
+
+-- Extra options --
+
+newoption {
+    trigger = 'test',
+    description = 'Build and execute tests'
+}
+
+newoption {
+    trigger = 'build',
+    value = 'build',
+    description = 'Build configuration',
+    allowed = {
+        { 'all', 'All' },
+        { 'app', 'Application' },
+        { 'test', 'Test' }
+    }
+}
+
+-- Extra actions --
 
 newaction {
     trigger = 'clean',
@@ -243,39 +326,4 @@ newaction {
         os.rmdir('./bin')
         print('Done')
     end
-}
-
-premake.override(premake.main, "postAction", function(base)
-    base()
-    io.flush()
-
-    if _OPTIONS['build'] == 'all' then
-
-    elseif _OPTIONS['build'] == 'app' then
-
-    elseif _OPTIONS['build'] == 'test' then
-
-    end
-
-    if _OPTIONS['test'] then
-        print('Running tests...');
-        io.flush()
-        os.execute('"'..path.getabsolute('.')..'/bin/x64/Test/StudyBox_CV"')
-    end
-end)
-
-newoption {
-    trigger = 'build',
-    value = 'build',
-    description = 'Build configuration',
-    allowed = {
-        {'all', 'All'},
-        {'app', 'Application'},
-        {'test', 'Test'}
-    }
-}
-
-newoption {
-    trigger = 'test',
-    description = 'Build and execute tests'
 }

--- a/premake5.lua
+++ b/premake5.lua
@@ -235,11 +235,46 @@ workspace 'StudyBox_CV'
         end
 
 newaction {
-   trigger = 'clean',
-   description = 'Removes build and bin directories',
-   execute = function()
-      os.rmdir('./build')
-      os.rmdir('./bin')
-      print('Done')
-   end
+    trigger = 'clean',
+    description = 'Removes build and bin directories',
+    execute = function()
+        os.rmdir('./build')
+        os.rmdir('./bin')
+        print('Done')
+    end
+}
+
+premake.override(premake.main, "postAction", function(base)
+    base()
+    io.flush()
+
+    if _OPTIONS['build'] == 'all' then
+
+    elseif _OPTIONS['build'] == 'app' then
+
+    elseif _OPTIONS['build'] == 'test' then
+
+    end
+
+    if _OPTIONS['test'] then
+        print('Running tests...');
+        io.flush()
+        os.execute('"'..path.getabsolute('.')..'/bin/x64/Test/StudyBox_CV"')
+    end
+end)
+
+newoption {
+    trigger = 'build',
+    value = 'build',
+    description = 'Build configuration',
+    allowed = {
+        {'all', 'All'},
+        {'app', 'Application'},
+        {'test', 'Test'}
+    }
+}
+
+newoption {
+    trigger = 'test',
+    description = 'Build and execute tests'
 }

--- a/premake5.lua
+++ b/premake5.lua
@@ -292,7 +292,7 @@ end)
 premake.override(premake.main, 'postAction', function(base)
     base()
 
-    local builds = {}
+    local builds = nil
     if _OPTIONS['build'] == 'all' then
         builds = { 'release', 'debug', 'test' }
     elseif _OPTIONS['build'] == 'app' then
@@ -317,7 +317,7 @@ premake.override(premake.main, 'postAction', function(base)
         setup.linux.tesseract()
     end
 
-    if next(builds) then
+    if builds then
         if action.os.type() == 'windows' then
             local file = io.open('build/nuget.exe')
             if file == nil then

--- a/premake5.lua
+++ b/premake5.lua
@@ -283,6 +283,15 @@ workspace 'StudyBox_CV'
 
 -- Premake overrides --
 
+premake.override(premake.main, 'preAction', function(base)
+    base()
+
+    if _OPTIONS['clean'] then
+        os.rmdir('./build')
+        os.rmdir('./bin')
+    end
+end)
+
 premake.override(premake.main, 'postAction', function(base)
     base()
 
@@ -314,6 +323,11 @@ newoption {
         { 'app', 'Application' },
         { 'test', 'Test' }
     }
+}
+
+newoption {
+    trigger = 'clean',
+    description = 'Remove build and bin directories'
 }
 
 -- Extra actions --

--- a/premake5.lua
+++ b/premake5.lua
@@ -5,6 +5,9 @@ workspace 'StudyBox_CV'
     configurations { 'Debug', 'Release', 'Test' }
     targetdir 'bin/%{cfg.platform}/%{cfg.buildcfg}'
 
+    platforms 'x64'
+    architecture 'x64'
+
     filter 'debug'
         flags 'Symbols'
         defines 'DEBUG'
@@ -14,9 +17,7 @@ workspace 'StudyBox_CV'
 
     filter 'action:vs*'
         defines { 'WIN32', 'NOMINMAX', 'NOGDI', 'ABSOLUTE_PATH="'..path.getabsolute('.')..'"' }
-        platforms { 'Win32', 'x64' }
     filter 'action:not vs*'
-        platforms { 'x32', 'x64' }
         buildoptions '-std=c++0x'
         defines { 'ABSOLUTE_PATH=\\"'..path.getabsolute('.')..'\\"' }
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -296,7 +296,18 @@ premake.override(premake.main, 'postAction', function(base)
     base()
 
     if action.os.type() == 'linux' then
-
+        local config = {}
+        if _OPTIONS['build'] == 'all' then
+            config = { 'release', 'debug', 'test' }
+        elseif _OPTIONS['build'] == 'app' then
+            config = { 'release' }
+        elseif _OPTIONS['build'] == 'test' or _OPTIONS['test'] then
+            config = { 'test' }
+        end
+        for k,v in pairs(config) do
+            print()
+            os.execute('cd build ; make config='..v..'_x64')
+        end
     elseif action.os.type() == 'windows' then
 
     end

--- a/premake5.lua
+++ b/premake5.lua
@@ -251,9 +251,6 @@ workspace 'StudyBox_CV'
                     '"$(TargetDir)\\$(TargetName).exe" --result_code=no --report_level=short'
                 }
 
-            setup.nuget.config()
-            setup.nuget.packages()
-
         elseif action.os.type() == 'linux' then
             includedirs {
                 'usr/local/include'
@@ -276,9 +273,6 @@ workspace 'StudyBox_CV'
                 links {
                     'boost_unit_test_framework'
                 }
-            setup.linux.boost()
-            setup.linux.opencv()
-            setup.linux.tesseract()
         end
 
 -- Premake overrides --
@@ -292,10 +286,6 @@ premake.override(premake.main, 'preAction', function(base)
         print('Cleaning bin and build directories...')
         os.rmdir('./build')
         os.rmdir('./bin')
-        if action.os.type() == 'windows' and _OPTIONS['build'] then
-            setup.nuget.config()
-            setup.nuget.packages()
-        end
     end
 end)
 
@@ -316,6 +306,15 @@ premake.override(premake.main, 'postAction', function(base)
         runs = 'Release'
     elseif _OPTIONS['run'] == 'test' or _OPTIONS['test'] then
         runs = 'Test'
+    end
+
+    if action.os.type() == 'windows' then
+        setup.nuget.config()
+        setup.nuget.packages()
+    elseif action.os.type() == 'linux' then
+        setup.linux.boost()
+        setup.linux.opencv()
+        setup.linux.tesseract()
     end
 
     if next(builds) then


### PR DESCRIPTION
Dodane zostały dodatkowe opcje do premake umożliwiające:
- budowanie (--build=<all;app;test>)
- uruchamianie (--run=<app;test>)
- testowanie (--test)
- czyszczenie (--clean)
Opcje można dowolnie łączyć, np. 'premake5 gmake --clean --build=app --run=app'.
Przełącznik '--test' jest równoważny '--build=test --run=test'
Przełącznik '--clean' usuwa foldery build i bin przed wykonaniem skryptu właściwego.